### PR TITLE
allow vat numbers without country code

### DIFF
--- a/Plugin/UidPlugin.php
+++ b/Plugin/UidPlugin.php
@@ -42,7 +42,8 @@ class UidPlugin
      */
     public function beforeCheckVatNumber(Vat $subject, $countryCode, $vatNumber, $requesterCountryCode = '', $requesterVatNumber = '')
     {
-        if($countryCode != $this->_helper->getCountryCodeFromVAT($vatNumber)){
+        $countryCodeFromVAT = $this->_helper->getCountryCodeFromVAT($vatNumber);
+        if(!is_numeric($countryCodeFromVAT) && $countryCode != $countryCodeFromVAT){
             $this->_messageManager->addError(__('Your selected country does not match the countrycode in VAT.'));
             return array();
         }


### PR DESCRIPTION
currently (M2.1.7) vat numbers without a country code are validated correctly. However, although the validation works, the message is displayed, that the vat number does not match the selected country code (because the vat number does not include a country code and the first two numbers are compared to the country code).

when debugging this, I see that the return array() results in the method receiving the original function call arguments (instead of an empty list like it seems to be desired here)

This change will only trigger the message, if the first two chars of the vat number are non numeric.