### PR TITLE
validate vat number is not empty

### DIFF
--- a/Plugin/UidPlugin.php
+++ b/Plugin/UidPlugin.php
@@ -43,7 +43,7 @@ class UidPlugin
     public function beforeCheckVatNumber(Vat $subject, $countryCode, $vatNumber, $requesterCountryCode = '', $requesterVatNumber = '')
     {
         $countryCodeFromVAT = $this->_helper->getCountryCodeFromVAT($vatNumber);
-        if(!is_numeric($countryCodeFromVAT) && $countryCode != $countryCodeFromVAT){
+        if(!empty($vatNumber) && !is_numeric($countryCodeFromVAT) && $countryCode != $countryCodeFromVAT){
             $this->_messageManager->addError(__('Your selected country does not match the countrycode in VAT.'));
             return array();
         }


### PR DESCRIPTION
Hi Roman,

I've made another change because now it was throwing the error message when the vat id was empty. I'm not sure if this also occurs in a default setup (we've made some changes to the vat validation) but this change should not be a problem, also. Just checking if the vat number is not empty.

Regards,
David