### PR TITLE
Fix issue with duplicate messages

### DIFF
--- a/Plugin/UidPlugin.php
+++ b/Plugin/UidPlugin.php
@@ -43,7 +43,8 @@ class UidPlugin
      */
     public function beforeCheckVatNumber(Vat $subject, $countryCode, $vatNumber, $requesterCountryCode = '', $requesterVatNumber = '')
     {
-        if($countryCode != $this->_helper->getCountryCodeFromVAT($vatNumber)){
+        $countryCodeFromVAT = $this->_helper->getCountryCodeFromVAT($vatNumber);
+        if(!empty($vatNumber) && !is_numeric($countryCodeFromVAT) && $countryCode != $countryCodeFromVAT){
             $this->addErrorMessageOnce(__('Your selected country does not match the countrycode in VAT.'));
             return array();
         }

--- a/Plugin/UidPlugin.php
+++ b/Plugin/UidPlugin.php
@@ -45,7 +45,7 @@ class UidPlugin
     {
         $countryCodeFromVAT = $this->_helper->getCountryCodeFromVAT($vatNumber);
         if(!empty($vatNumber) && !is_numeric($countryCodeFromVAT) && $countryCode != $countryCodeFromVAT){
-            $this->addErrorMessageOnce(__('Your selected country does not match the countrycode in VAT.'));
+            $this->addErrorMessage(__('Your selected country does not match the countrycode in VAT.'));
             return array();
         }
         $newVatNumber = $vatNumber;
@@ -61,10 +61,10 @@ class UidPlugin
     }
 
     /**
-     * @param $errorMsg
+     * @param string $errorMsg
      * @return bool
      */
-    private function addErrorMessageOnce($errorMsg)
+    private function addErrorMessage($errorMsg)
     {
         foreach ($this->_messageManager->getMessages() as $message) {
             /** @var MessageInterface $message */


### PR DESCRIPTION
I'm using your module to beautify the VAT validation process - thanks for this! However, when a customer messes around too much, the same error message keeps coming up multiple times. This ends up showing  the same error numerous times on the screen, when in the end the messages are shown. This PR fixes this. It is kind of silly that Magento does not have something like this on board yet, but hey, different story.